### PR TITLE
Add build targets for optox

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you use this code, please cite
 ```
 git clone https://github.com/midas-tum/optox.git
 cd optox
-python3 install.py
+python3 install.py --python --pytorch --tensorflow --gpunufft
 ```
 
 follow build instructions on the github.


### PR DESCRIPTION
Currently the README indicates that running `python install.py` is sufficient to build optox.  However in order to generate install targets via CMake, one has to specify which targets are to be built.

tl;dr: Appended  `--python --pytorch --tensorflow --gpunufft` to `python install.py`